### PR TITLE
First Stable Release v1.0.0

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,134 @@
+# Pull Request Labeling Rules based on changed files
+# https://github.com/actions/labeler
+
+
+####### LABELS based on FILE CHANGES #######
+
+# Here, we declare Rules for Labeling PR based on the file changes
+
+# Each Label is added, when their Rule(s) are True
+# - 'any' block is True, if any of the conditions are True
+# - 'all' block is True, if all of the conditions are True
+
+# Typically a Label, only features one of 'any' or 'all' block
+
+# Each label declares Rules that are mutually exclusive, in boolean logic.
+# Thus, the set of matching file paths are non-overlapping, across the labels.
+
+
+### SRC ###
+# Add 'business_logic' label to any change within the 'src/cookiecutter_python' dir
+business_logic:
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - 'src/changelog_ci/*'
+        - 'src/changelog_ci/*'
+
+stubs:
+  - any:
+    - changed-files:
+      - any-glob-to-any-file: ['src/stubs/*', 'src/stubs/**/*']
+
+### TESTS ###
+## Add 'test' label to any change within the 'tests' dir #
+test:
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - 'tests/*'
+        - 'tests/**/*'
+
+  # exclude any changes within the 'tests/data/' dir
+  - all:
+    - changed-files:
+      - all-globs-to-all-files:
+        - '!tests/data/*'
+        - '!tests/data/**/*'
+
+test_data:
+  - any:
+    - changed-files:
+      - any-glob-to-any-file: ['tests/data/*', 'tests/data/**/*']
+
+### DOCS ###
+# Any change within the 'docs' dir, or the '.readthedocs.yml' file
+docs:
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - 'docs/*'
+        - 'docs/**/*'
+        - '.readthedocs.yml'
+        - 'README.rst'
+        - 'README.md'
+
+### SCRIPTS ###
+scripts:
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - 'scripts/**'
+
+### CI ###
+# Add 'ci' label to any change within the '.github' dir
+ci:
+  - any:
+    - changed-files:
+      - any-glob-to-any-file: ['.github/*', '.github/**/*']
+
+### DOCKER ###
+docker:
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - 'Dockerfile'
+        - 'docker-compose.yml'
+        - 'docker-compose.*.yml'
+        - '.dockerignore'
+
+### POETRY ###
+poetry:
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - 'pyproject.toml'
+        - 'poetry.lock'
+
+### TOX ###
+tox:
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - 'tox.ini'
+
+config:
+  - any:
+    - changed-files:
+      - any-glob-to-any-file:
+        - '.bettercodehub.yml'
+        - '.coveragerc'
+        - '.gitignore'
+        - '.prospector.yml'
+        - '.pylintrc'
+
+
+####### LABELS based on BRANCH NAME #######
+
+## Pull Request Labeling Rules based Base Branch
+
+# Add 'release' label to any PR that is opened against the `main` branch
+release:
+  - base-branch: 'main'
+
+# Add 'boarding_auto' label to any PR that is opened against the `boarding-auto` branch
+# [GITOPS]: This should act as a signal, ie for a Listener Workflow to Merge the PR
+boarding_auto:
+  - base-branch: ['^boarding-auto', 'boarding-auto']
+  - base-branch: ['^board-n-release', 'board-n-release']
+
+
+# Add 'feature' label to any PR where the head branch name starts with
+# `feature` or has a `feature` section in the name
+feature:
+  - head-branch: ['^feature', 'feature']

--- a/.github/workflows/_signal_deploy.yml
+++ b/.github/workflows/_signal_deploy.yml
@@ -1,0 +1,79 @@
+name: 'Signal Automated Deployment'
+
+on:
+  workflow_call:
+    inputs:
+      main_branch:
+        description: 'The name of the main branch'
+        required: true
+        default: 'main'
+        type: string
+      release_branch:
+        description: 'The name of the release branch'
+        required: true
+        default: 'release'
+        type: string
+    outputs:
+      AUTOMATED_DEPLOY:
+        description: "Boolean value to signal if the automated deployment should happen"
+        value: ${{ jobs.check_which_git_branch_we_are_on.outputs.AUTOMATED_DEPLOY }}
+      ENVIRONMENT_NAME:
+        description: "Github Environment Name that should be used for deployment"
+        value: ${{ jobs.check_which_git_branch_we_are_on.outputs.ENVIRONMENT_NAME }}
+
+jobs:
+  ## JOB: Signal for Automated PyPI Upload ##
+  check_which_git_branch_we_are_on:
+    runs-on: ubuntu-latest
+    # logic below assumes github.ref is a tag, so we allow to run only on tag push
+    # PROD if: startsWith(github.ref, 'refs/tags/')
+    env:
+      RELEASE_BR: ${{ inputs.release_branch }}
+      MAIN_BR: ${{ inputs.main_branch }}
+    outputs:
+      AUTOMATED_DEPLOY: ${{ steps.set_environment_name.outputs.AUTOMATED_DEPLOY }}
+      ENVIRONMENT_NAME: ${{ steps.set_environment_name.outputs.ENVIRONMENT_NAME }}
+    steps:
+      # Fetch 'main' and 'release' branches
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.MAIN_BR }}
+
+      - id: track_release_br
+        run: |
+          remote_release_branch_is_tracked=true
+          git branch --track "${{ env.RELEASE_BR }}" "origin/${{ env.RELEASE_BR }}" || remote_release_branch_is_tracked=false
+          echo "TRACKED_RELEASE=${remote_release_branch_is_tracked}" >> $GITHUB_OUTPUT
+          if [ $remote_release_branch_is_tracked = 'false' ]]; then
+            echo "[WARN] Could not track '${{ env.RELEASE_BR }}' branch. Possibly origin/${{ env.RELEASE_BR }} has been already deleted"
+          fi
+
+      - name: "Check if '${{ github.ref }}' tag is on '${{ env.MAIN_BR }}' branch"
+        uses: rickstaa/action-contains-tag@a9ff27d505ba2bf074a2ebb48b208e76d35ff308
+        id: main_contains_tag
+        with:
+          reference: ${{ env.MAIN_BR }}
+          tag: "${{ github.ref }}"
+
+      - name: "Check if '${{ github.ref }}' tag is on '${{ env.RELEASE_BR }}' branch"
+        if: steps.track_release_br.outputs.TRACKED_RELEASE == 'true'
+        uses: rickstaa/action-contains-tag@a9ff27d505ba2bf074a2ebb48b208e76d35ff308
+        id: release_contains_tag
+        with:
+          reference: ${{ env.RELEASE_BR }}
+          tag: "${{ github.ref }}"
+
+      - name: Pick Production or Test Environment, if tag on MAIN_BR or release branch respectively
+        id: set_environment_name
+        run: |
+          DEPLOY=true
+          if [[ "${{ steps.main_contains_tag.outputs.retval }}" == "true" ]]; then
+            echo "ENVIRONMENT_NAME=PROD_DEPLOYMENT" >> $GITHUB_OUTPUT
+          elif [[ "${{ steps.release_contains_tag.outputs.retval }}" == "true" ]]; then
+            echo "ENVIRONMENT_NAME=TEST_DEPLOYMENT" >> $GITHUB_OUTPUT
+          else
+            echo "[WARN] Could find a tag either on ${MAIN_BR} or ${RELEASE_BR} branch."
+            DEPLOY=false
+          fi
+          echo "AUTOMATED_DEPLOY=$DEPLOY" >> $GITHUB_OUTPUT

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJSON(inputs.test_matrix) }}
+      fail-fast: false  # allow Test Cases to continue running when another one fails
     env:
       TEST_MAIN: main
       TEST_REPO: 'boromir674/gitops-automation'

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -90,16 +90,17 @@ jobs:
         # ASSERT MARKDOWN Content with Unicode string comparison
         if: always() && matrix.test_data.action_inputs.output_format == 'MD'
         env:
-          # implicit convertion to string, by serializing inner json array representation
-          EXPECTED_COMMITS_GROUPS: ${{ toJSON(matrix.test_data.expected_groups) }}
-          ACTION_COMMITS_GROUPS: ${{ matrix.test_data.action_inputs.output_format == 'MD' && format('"{0}"', steps.run_action.outputs.content) || toJSON(steps.run_action.outputs.content) }}
+          ACTION_COMMITS_GROUPS: ${{ matrix.test_data.action_inputs.output_format == 'MD' && format('"{0}"', steps.run_action.outputs.content) }}
         run: |
-          if [ ${{ env.ACTION_COMMITS_GROUPS }} = ${{ matrix.test_data.action_inputs.output_format == 'MD' && format('"{0}"', env.EXPECTED_MARKDOWN_CONTENT) || toJSON(env.EXPECTED_COMMITS_GROUPS) }} ]; then
+
+          if [ ${{ env.ACTION_COMMITS_GROUPS }} = ${{ format('"{0}"', env.EXPECTED_MARKDOWN_CONTENT) }} ]; then
             echo "Action Return Value is as expected."
           else
             echo "Action Return Value is NOT as expected."
             exit 1
           fi
+
+      # if [ ${{ env.ACTION_COMMITS_GROUPS }} = ${{ matrix.test_data.action_inputs.output_format == 'MD' && format('"{0}"', env.EXPECTED_MARKDOWN_CONTENT) || toJSON(env.EXPECTED_COMMITS_GROUPS) }} ]; then
 
       - name: Print Runtime and Expected for sanity check
         if: always()

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -77,8 +77,6 @@ jobs:
           echo "${EXPECTED_MARKDOWN_CONTENT}" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
-          # echo EXPECTED_MARKDOWN_CONTENT="${EXPECTED_MARKDOWN_CONTENT}" >> $GITHUB_ENV
-
       # THEN the Action should return the expected Markdown content
       # jq --exit-status --argjson expected "${EXPECTED_COMMITS_GROUPS}" '$expected == .' <<< ${{ toJSON(steps.run_action.outputs.conten) }}
       
@@ -87,7 +85,7 @@ jobs:
           # implicit convertion to string, by serializing inner json array representation
           EXPECTED_COMMITS_GROUPS: ${{ toJSON(matrix.test_data.expected_groups) }}
         run: |
-          if [ "${{ steps.run_action.outputs.content }}" = "${EXPECTED_MARKDOWN_CONTENT}" ]; then
+          if [ "${{ steps.run_action.outputs.content }}" = "${{ matrix.test_data.action_inputs.output_format == 'MD' && env.EXPECTED_MARKDOWN_CONTENT || env.EXPECTED_COMMITS_GROUPS }}" ]; then
             echo "Action Return Value is as expected."
           else
             echo "Action Return Value is NOT as expected."

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -116,6 +116,6 @@ jobs:
         if: always()
         run: |
           echo "### Action Return Value" >> $GITHUB_STEP_SUMMARY
-          echo '```${{ matrix.test_data.action_inputs.output_format == 'JSON' && 'json' }}' >> $GITHUB_STEP_SUMMARY
+          echo '```${{ matrix.test_data.action_inputs.output_format == 'JSON' && 'json' || 'markdown' }}' >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.run_action.outputs.content }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -1,0 +1,105 @@
+name: Test expected content is returned, when Categories supplied as Action Input
+on:
+  workflow_call:
+    inputs:
+      test_matrix:
+        description: 'JSON Object like {"test_data": [{...}]}; the Job Matrix: A JSON object of key (factors) mapping to arrays (of test cases to run).'
+        required: true
+        type: string
+jobs:
+  test_job_matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJSON(inputs.test_matrix) }}
+    env:
+      TEST_MAIN: main
+      TEST_REPO: 'boromir674/gitops-automation'
+      _BRANCH: "emulated-feature-branch-${{ github.run_id }}"
+      # Design of Expected Groups leverages a json array of objects
+      # implicit convertion to string, by serializing inner json array representation
+      EXPECTED_COMMITS_GROUPS: ${{ toJSON(matrix.test_data.expected_groups) }}
+      # implicit convertion to string, by serializing inner json array representation
+      COMMITS_JSON_ARRAY_SERIALIZED: ${{ toJSON(matrix.test_data.action_inputs.commits) }}
+    steps:
+      # GIVEN a list of Commits (Subject text), as JSON array of strings
+      - name: Print Test Case Data, from evaluated Input JSON Object
+        run: |
+          echo 'Commits: ${{ toJSON(matrix.test_data.action_inputs.commits) }}'
+          echo 'Format: ${{ matrix.test_data.action_inputs.output_format }}'
+          echo 'Categories: ${{ matrix.test_data.action_inputs.categories }}'
+          echo 'Expected Groups: ${{ matrix.test_data.expected_groups }}'
+
+      # GIVEN a git repository locally checked out
+      - name: Checkout '${{ env.TEST_REPO }}' Compatible Repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.TEST_REPO }}
+          ref: ${{ env.TEST_MAIN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+        # GIVEN a the requested output_format is 'MD'. for Markdown
+        # GIVEN the User requested to get grouped output
+        # GIVEN the User supply their Categories as Action Input
+      # WHEN the Action runs
+      - name: WHEN Action Runs, with Categories supplied as Input
+        id: run_action
+        uses: boromir674/action-generate-changelog@dev
+        with:
+          commits: ${{ env.COMMITS_JSON_ARRAY_SERIALIZED }}
+          output_format: '${{ matrix.test_data.action_inputs.output_format }}'
+          # group: ${{ matrix.test_data.action_inputs.group }}
+          categories: ${{ matrix.test_data.action_inputs.categories }}
+
+      - name: IF 'MD' is requested, convert the Expected Groups from JSON Array of Objects to Markdown
+        if: ${{ matrix.test_data.action_inputs.output_format == 'MD' }}
+        run: |
+          # keep 'markdown_section_name' (str) and 'commits' (array of strings) keys from Expected array of objects
+          expected_content=$(echo "${EXPECTED_COMMITS_GROUPS}" | jq -c '[.[] | {markdown_section_name: .markdown_section_name, commits: .commits}]')
+
+          echo "[DEBUG] $(echo ${expected_content} | jq)"
+          echo
+
+          # Convert to Markdown like
+          # ## Section Name
+          # - commit 1
+          # - commit 2
+          # ...
+          # EXPECTED_MARKDOWN_CONTENT=$(echo "${expected_content}" | jq -r 'map("## \(.markdown_section_name)\n\(.commits | map("- \(.)) | join("\n")) | join("\n\n")')
+
+          EXPECTED_MARKDOWN_CONTENT=$(echo "${expected_content}" | jq -r 'map("## \(.markdown_section_name)\n\(.commits | map("- \(.)") | join("\n"))") | join("\n\n")')
+
+          echo "[DEBUG] EXPECTED_MARKDOWN_CONTENT:"
+          echo ${EXPECTED_MARKDOWN_CONTENT}
+
+          # Store the multi-line markdown content in a GitHub environment variable
+          echo "EXPECTED_MARKDOWN_CONTENT<<EOF" >> $GITHUB_ENV
+          echo "${EXPECTED_MARKDOWN_CONTENT}" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+          # echo EXPECTED_MARKDOWN_CONTENT="${EXPECTED_MARKDOWN_CONTENT}" >> $GITHUB_ENV
+
+      # THEN the Action should return the expected Markdown content
+      # jq --exit-status --argjson expected "${EXPECTED_COMMITS_GROUPS}" '$expected == .' <<< ${{ toJSON(steps.run_action.outputs.conten) }}
+      
+      - name: ASSERT Expected Markdown is returned
+        env:
+          # implicit convertion to string, by serializing inner json array representation
+          EXPECTED_COMMITS_GROUPS: ${{ toJSON(matrix.test_data.expected_groups) }}
+        run: |
+          if [ "${{ steps.run_action.outputs.content }}" = "${EXPECTED_MARKDOWN_CONTENT}" ]; then
+            echo "Action Return Value is as expected."
+          else
+            echo "Action Return Value is NOT as expected."
+            exit 1
+          fi
+
+      - name: Print Runtime and Expected for sanity check
+        if: always()
+        run: |
+          echo "[DEBUG] Runtime RAW Output:"
+          echo '${{ steps.run_action.outputs.content }}'
+          echo
+
+          echo "[DEBUG] Expected Output:"
+          echo "${{ matrix.test_data.action_inputs.output_format == 'MD' && env.EXPECTED_MARKDOWN_CONTENT || env.EXPECTED_COMMITS_GROUPS }}"

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -27,7 +27,7 @@ jobs:
           echo 'Commits: ${{ toJSON(matrix.test_data.action_inputs.commits) }}'
           echo 'Format: ${{ matrix.test_data.action_inputs.output_format }}'
           echo 'Categories: ${{ matrix.test_data.action_inputs.categories }}'
-          echo 'Expected Groups: ${{ matrix.test_data.expected_groups }}'
+          echo 'Expected Groups: ${{ toJSON(matrix.test_data.expected_groups) }}'
 
       # GIVEN a git repository locally checked out
       - name: Checkout '${{ env.TEST_REPO }}' Compatible Repository
@@ -41,6 +41,7 @@ jobs:
         # GIVEN a the requested output_format is 'MD'. for Markdown
         # GIVEN the User requested to get grouped output
         # GIVEN the User supply their Categories as Action Input
+
       # WHEN the Action runs
       - name: WHEN Action Runs, with Categories supplied as Input
         id: run_action
@@ -78,7 +79,6 @@ jobs:
           echo "EOF" >> $GITHUB_ENV
 
       # THEN the Action should return the expected content
-
       - name: ASSERT Action JSON array is same as EXPECTED, using jq
         # ASSERT JSON Content leveraging JQ to disregard space characters and/or \n
         if: ${{ matrix.test_data.action_inputs.output_format == 'JSON' }}
@@ -99,8 +99,6 @@ jobs:
             echo "Action Return Value is NOT as expected."
             exit 1
           fi
-
-      # if [ ${{ env.ACTION_COMMITS_GROUPS }} = ${{ matrix.test_data.action_inputs.output_format == 'MD' && format('"{0}"', env.EXPECTED_MARKDOWN_CONTENT) || toJSON(env.EXPECTED_COMMITS_GROUPS) }} ]; then
 
       - name: Print Runtime and Expected for sanity check
         if: always()

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -117,5 +117,5 @@ jobs:
         run: |
           echo "### Action Return Value" >> $GITHUB_STEP_SUMMARY
           echo '```${{ matrix.test_data.action_inputs.output_format == 'JSON' && 'json' || 'markdown' }}' >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.run_action.outputs.content }}" >> $GITHUB_STEP_SUMMARY
+          echo ${{ matrix.test_data.action_inputs.output_format == 'JSON' && format('{0} | jq', toJSON(steps.run_action.outputs.content)) || format('"{0}"', steps.run_action.outputs.content) }} >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -77,15 +77,24 @@ jobs:
           echo "${EXPECTED_MARKDOWN_CONTENT}" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
-      # THEN the Action should return the expected Markdown content
-      # jq --exit-status --argjson expected "${EXPECTED_COMMITS_GROUPS}" '$expected == .' <<< ${{ toJSON(steps.run_action.outputs.conten) }}
-      
-      - name: ASSERT Expected Markdown is returned
+      # THEN the Action should return the expected content
+
+      - name: ASSERT Action JSON array is same as EXPECTED, using jq
+        # ASSERT JSON Content leveraging JQ to disregard space characters and/or \n
+        if: ${{ matrix.test_data.action_inputs.output_format == 'JSON' }}
+        # env:
+        #   ACTION_COMMITS_GROUPS: ${{ toJSON(steps.run_action.outputs.content) }}
+        run: jq --exit-status --argjson expected "${EXPECTED_COMMITS_GROUPS}" '$expected == .' <<< ${{ toJSON(steps.run_action.outputs.content) }}
+
+      - name: ASSERT Expected Content is returned, using Unicode string comparison
+        # ASSERT MARKDOWN Content with Unicode string comparison
+        if: always() && matrix.test_data.action_inputs.output_format == 'MD'
         env:
           # implicit convertion to string, by serializing inner json array representation
           EXPECTED_COMMITS_GROUPS: ${{ toJSON(matrix.test_data.expected_groups) }}
+          ACTION_COMMITS_GROUPS: ${{ matrix.test_data.action_inputs.output_format == 'MD' && format('"{0}"', steps.run_action.outputs.content) || toJSON(steps.run_action.outputs.content) }}
         run: |
-          if [ "${{ steps.run_action.outputs.content }}" = "${{ matrix.test_data.action_inputs.output_format == 'MD' && env.EXPECTED_MARKDOWN_CONTENT || env.EXPECTED_COMMITS_GROUPS }}" ]; then
+          if [ ${{ env.ACTION_COMMITS_GROUPS }} = ${{ matrix.test_data.action_inputs.output_format == 'MD' && format('"{0}"', env.EXPECTED_MARKDOWN_CONTENT) || toJSON(env.EXPECTED_COMMITS_GROUPS) }} ]; then
             echo "Action Return Value is as expected."
           else
             echo "Action Return Value is NOT as expected."

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -101,3 +101,11 @@ jobs:
 
           echo "[DEBUG] Expected Output:"
           echo "${{ matrix.test_data.action_inputs.output_format == 'MD' && env.EXPECTED_MARKDOWN_CONTENT || env.EXPECTED_COMMITS_GROUPS }}"
+
+      - name: Render Returned Content as Job Summary
+        if: always()
+        run: |
+          echo "### Action Return Value" >> $GITHUB_STEP_SUMMARY
+          echo '```${{ matrix.test_data.action_inputs.output_format == 'JSON' && 'json' }}' >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.run_action.outputs.content }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -154,6 +154,27 @@ jobs:
                   ]
                 }
               ]
+            },
+            {
+              "name": "Test 3 expected JSON is returned, when Categories are supplied as Action Input",
+              "action_inputs": {
+                "commits": [
+                  "feat: new feature 2",
+                  "feat: new feature 1"
+                ],
+                "output_format": "JSON",
+                "categories": "feat,fix,refactor,test,build,docs,ci,style,chore"
+              },
+              "expected_groups": [
+                {
+                  "category": "feat",
+                  "markdown_section_name": "feat",
+                  "commits": [
+                    "feat: new feature 2",
+                    "feat: new feature 1"
+                  ]
+                }
+              ]
             }
           ]
         }

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -125,7 +125,6 @@ jobs:
               "expected_groups": [
                 {
                   "category": "feat",
-                  "markdown_section_name": "feat",
                   "commits": [
                     "feat: new feature 2",
                     "feat: new feature 1"
@@ -133,14 +132,12 @@ jobs:
                 },
                 {
                   "category": "fix",
-                  "markdown_section_name": "fix",
                   "commits": [
                     "fix: bug fix"
                   ]
                 },
                 {
                   "category": "test",
-                  "markdown_section_name": "test",
                   "commits": [
                     "test: test 2",
                     "test: test 1"
@@ -148,7 +145,6 @@ jobs:
                 },
                 {
                   "category": "chore",
-                  "markdown_section_name": "chore",
                   "commits": [
                     "chore: chore 1"
                   ]

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -46,64 +46,64 @@ jobs:
                   "category": "feat",
                   "markdown_section_name": "feat",
                   "commits": [
-                    "feat: new feature 2",
-                    "feat: new feature 1"
+                    "new feature 2",
+                    "new feature 1"
                   ]
                 },
                 {
                   "category": "fix",
                   "markdown_section_name": "fix",
                   "commits": [
-                    "fix: bug fix"
+                    "bug fix"
                   ]
                 },
                 {
                   "category": "refactor",
                   "markdown_section_name": "refactor",
                   "commits": [
-                    "refactor: code refactor"
+                    "code refactor"
                   ]
                 },
                 {
                   "category": "test",
                   "markdown_section_name": "test",
                   "commits": [
-                    "test: test"
+                    "test"
                   ]
                 },
                 {
                   "category": "build",
                   "markdown_section_name": "build",
                   "commits": [
-                    "build: build"
+                    "build"
                   ]
                 },
                 {
                   "category": "docs",
                   "markdown_section_name": "docs",
                   "commits": [
-                    "docs: docs"
+                    "docs"
                   ]
                 },
                 {
                   "category": "ci",
                   "markdown_section_name": "ci",
                   "commits": [
-                    "ci: ci"
+                    "ci"
                   ]
                 },
                 {
                   "category": "style",
                   "markdown_section_name": "style",
                   "commits": [
-                    "style: style"
+                    "style"
                   ]
                 },
                 {
                   "category": "chore",
                   "markdown_section_name": "chore",
                   "commits": [
-                    "chore: chore"
+                    "chore"
                   ]
                 }
               ]
@@ -126,27 +126,27 @@ jobs:
                 {
                   "category": "feat",
                   "commits": [
-                    "feat: new feature 2",
-                    "feat: new feature 1"
+                    "new feature 2",
+                    "new feature 1"
                   ]
                 },
                 {
                   "category": "fix",
                   "commits": [
-                    "fix: bug fix"
+                    "bug fix"
                   ]
                 },
                 {
                   "category": "test",
                   "commits": [
-                    "test: test 2",
-                    "test: test 1"
+                    "test 2",
+                    "test 1"
                   ]
                 },
                 {
                   "category": "chore",
                   "commits": [
-                    "chore: chore 1"
+                    "chore 1"
                   ]
                 }
               ]
@@ -165,8 +165,8 @@ jobs:
                 {
                   "category": "feat",
                   "commits": [
-                    "feat: new feature 2",
-                    "feat: new feature 1"
+                    "new feature 2",
+                    "new feature 1"
                   ]
                 }
               ]

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -24,7 +24,7 @@ jobs:
         {
           "test_data": [
             {
-              "name": "Test expected Markdown is returned, when Categories are supplied as Action Input",
+              "name": "Test 1 expected Markdown is returned, when Categories are supplied as Action Input",
               "action_inputs": {
                 "commits": [
                   "feat: new feature 2",
@@ -104,6 +104,53 @@ jobs:
                   "markdown_section_name": "chore",
                   "commits": [
                     "chore: chore"
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "Test 2 expected JSON is returned, when Categories are supplied as Action Input",
+              "action_inputs": {
+                "commits": [
+                  "feat: new feature 2",
+                  "fix: bug fix",
+                  "test: test 2",
+                  "test: test 1",
+                  "feat: new feature 1",
+                  "chore: chore 1"
+                ],
+                "output_format": "JSON",
+                "categories": "feat,fix,refactor,test,build,docs,ci,style,chore"
+              },
+              "expected_groups": [
+                {
+                  "category": "feat",
+                  "markdown_section_name": "feat",
+                  "commits": [
+                    "feat: new feature 2",
+                    "feat: new feature 1"
+                  ]
+                },
+                {
+                  "category": "fix",
+                  "markdown_section_name": "fix",
+                  "commits": [
+                    "fix: bug fix"
+                  ]
+                },
+                {
+                  "category": "test",
+                  "markdown_section_name": "test",
+                  "commits": [
+                    "test: test 2",
+                    "test: test 1"
+                  ]
+                },
+                {
+                  "category": "chore",
+                  "markdown_section_name": "chore",
+                  "commits": [
+                    "chore: chore 1"
                   ]
                 }
               ]

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,174 @@
+# Continuous Integration / Continuous Delivery
+name: CI/CD Pipeline
+on:
+  push:
+    branches:
+      - "*"
+      # do not do CI on 'release' and 'develop' branches
+      - '!release'
+      - '!develop'
+    tags:
+      - v*.*.*
+env:
+  ##### JOB ON/OFF SWITCHES - Top/1st level overrides #####
+  RUN_UNIT_TESTS: "true"
+  DOCS_ON: "true"
+  ###############################
+
+  #### DOCS Build/Test ####
+  ALWAYS_DOCS: "false"
+  DOCS_JOB_POLICY: '2'  # {2, 3}
+  DOCS_BUILDER_RUNTIME: "3.10"
+  ##########################
+
+jobs:
+  ### TEST Action returns 'true' in Rule-passing End-2-End Scenarios ###
+  test:
+    if: vars.OVERRIDE_UNIT_TESTS == 'true' || vars.OVERRIDE_UNIT_TESTS != 'false'
+    uses: ./.github/workflows/_test.yml
+    with:
+      test_matrix: |
+        {
+          "test_data": [
+            {
+              "name": "Test expected Markdown is returned, when Categories are supplied as Action Input",
+              "action_inputs": {
+                "commits": [
+                  "feat: new feature",
+                  "fix: bug fix",
+                  "refactor: code refactor",
+                  "test: test",
+                  "build: build",
+                  "docs: docs",
+                  "ci: ci",
+                  "style: style",
+                  "chore: chore"
+                ],
+                "output_format": "MD",
+                "categories": "feat,fix,refactor,test,build,docs,ci,style,chore"
+              },
+              "expected_groups": [
+                {
+                  "category": "feat",
+                  "markdown_section_name": "Feature",
+                  "commits": [
+                    "feat: new feature"
+                  ]
+                },
+                {
+                  "category": "fix",
+                  "markdown_section_name": "Fix",
+                  "commits": [
+                    "fix: bug fix"
+                  ]
+                },
+                {
+                  "category": "refactor",
+                  "markdown_section_name": "Refactor",
+                  "commits": [
+                    "refactor: code refactor"
+                  ]
+                },
+                {
+                  "category": "test",
+                  "markdown_section_name": "Test",
+                  "commits": [
+                    "test: test"
+                  ]
+                },
+                {
+                  "category": "build",
+                  "markdown_section_name": "Build",
+                  "commits": [
+                    "build: build"
+                  ]
+                },
+                {
+                  "category": "docs",
+                  "markdown_section_name": "Documentation",
+                  "commits": [
+                    "docs: docs"
+                  ]
+                },
+                {
+                  "category": "ci",
+                  "markdown_section_name": "CI",
+                  "commits": [
+                    "ci: ci"
+                  ]
+                },
+                {
+                  "category": "style",
+                  "markdown_section_name": "Style",
+                  "commits": [
+                    "style: style"
+                  ]
+                },
+                {
+                  "category": "chore",
+                  "markdown_section_name": "Other",
+                  "commits": [
+                    "chore: chore"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+
+  ### DOCS BUILD/TEST - DOCUMENTATION SITE ###
+  docs:
+    # IF PIPE_DOCS_POLICY != 0, will trigger by processing rules in order till TRUE
+    # - run_policy == 1
+    # - push event on 'main' branch AND run_policy == 2
+    # - push event of "v*" tag AND run_policy == 2
+    # - Documentation Changes Detected
+    name: Build Documentation
+    uses: boromir674/automated-workflows/.github/workflows/policy_docs.yml@v1.13.1
+    with:
+      # 0: OFF, 1: Always, 2: Content Dynamic + Dedicated Branches, 3: Content Dynamic
+      run_policy: "${{ (vars.OVERRIDE_DOCS == 'false' && '0') || (vars.OVERRIDE_DOCS == 'true' && '1') || '2' }}"
+      python_version: '3.10'
+      dedicated_branches: 'main, release'  #  only relevant when policy = 2
+      command: 'tox -s false -e pin-deps -- -E docs && tox -e docs --sitepackages -vv -s false'
+
+  ### CI Checks - Quality Logic Gate ###
+  quality_gate:
+    # This Workflow implements both CI and CD, with its Jobs.
+    # So we put the Quality Gate for Dynamic Acceptance/Check here, which should be wired up to the CI Jobs.
+    if: always()
+    needs: ['test', 'docs']
+    uses: boromir674/automated-workflows/.github/workflows/go-single-status.yml@v1.13.1
+    with:
+      # leverage inputs to dynamically control the Acceptance Criteria
+      # by default all job.needs Jobs must be Green
+
+      # - This Gate can be used as an abstraction between CI and CD
+      # - This Gate can be used as an abstraction CI Checks and Branch Protection Rules.Required_Checks
+
+      # - dynamically add discovered skipped Jobs to the 'allowed-skips', on branch push
+      # - on tag push all needed Jobs must succeed for Gate to pass
+      allowed-skips: ${{ ( ! startsWith(github.event.ref, 'refs/tags/v') && needs.*.result == 'skipped') || '[]' }}
+      needs_json: ${{ toJSON(needs) }}  # should never change
+
+  ### CD Signal ###
+  signal_deploy:
+    needs: quality_gate
+    if: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
+    uses: ./.github/workflows/_signal_deploy.yml
+    with:
+      main_branch: ${{ vars.GIT_MAIN_BRANCH || 'main' }}
+      release_branch: ${{ vars.GIT_RELEASE_BRANCH || 'release' }}
+
+  ### Make a Github Release ###
+  gh_release:
+    needs: signal_deploy
+    if: always() && ( vars.OVERRIDE_DEPLOY == 'true' || ( vars.OVERRIDE_DEPLOY != 'false' && needs.signal_deploy.outputs.AUTOMATED_DEPLOY == 'true' ) )
+    uses: boromir674/automated-workflows/.github/workflows/gh-release.yml@v1.13.1
+    name: 'GH Release'
+    with:
+      tag: ${{ github.ref_name }}
+      draft: ${{ needs.check_which_git_branch_we_are_on.outputs.ENVIRONMENT_NAME == 'TEST_DEPLOYMENT' }}
+    secrets:
+      # passing the GH_TOKEN PAT, to render in GH as ie: 'boromir674 released this yesterday', instead of 'github-actions released this yesterday'
+      gh_token: ${{ secrets.GH_TOKEN_CREATE_RELEASE }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -27,10 +27,11 @@ jobs:
               "name": "Test expected Markdown is returned, when Categories are supplied as Action Input",
               "action_inputs": {
                 "commits": [
-                  "feat: new feature",
+                  "feat: new feature 2",
                   "fix: bug fix",
                   "refactor: code refactor",
                   "test: test",
+                  "feat: new feature 1",
                   "build: build",
                   "docs: docs",
                   "ci: ci",
@@ -45,7 +46,8 @@ jobs:
                   "category": "feat",
                   "markdown_section_name": "feat",
                   "commits": [
-                    "feat: new feature"
+                    "feat: new feature 2",
+                    "feat: new feature 1"
                   ]
                 },
                 {

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -168,7 +168,6 @@ jobs:
               "expected_groups": [
                 {
                   "category": "feat",
-                  "markdown_section_name": "feat",
                   "commits": [
                     "feat: new feature 2",
                     "feat: new feature 1"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -50,63 +50,63 @@ jobs:
               "expected_groups": [
                 {
                   "category": "feat",
-                  "markdown_section_name": "Feature",
+                  "markdown_section_name": "feat",
                   "commits": [
                     "feat: new feature"
                   ]
                 },
                 {
                   "category": "fix",
-                  "markdown_section_name": "Fix",
+                  "markdown_section_name": "fix",
                   "commits": [
                     "fix: bug fix"
                   ]
                 },
                 {
                   "category": "refactor",
-                  "markdown_section_name": "Refactor",
+                  "markdown_section_name": "refactor",
                   "commits": [
                     "refactor: code refactor"
                   ]
                 },
                 {
                   "category": "test",
-                  "markdown_section_name": "Test",
+                  "markdown_section_name": "test",
                   "commits": [
                     "test: test"
                   ]
                 },
                 {
                   "category": "build",
-                  "markdown_section_name": "Build",
+                  "markdown_section_name": "build",
                   "commits": [
                     "build: build"
                   ]
                 },
                 {
                   "category": "docs",
-                  "markdown_section_name": "Documentation",
+                  "markdown_section_name": "docs",
                   "commits": [
                     "docs: docs"
                   ]
                 },
                 {
                   "category": "ci",
-                  "markdown_section_name": "CI",
+                  "markdown_section_name": "ci",
                   "commits": [
                     "ci: ci"
                   ]
                 },
                 {
                   "category": "style",
-                  "markdown_section_name": "Style",
+                  "markdown_section_name": "style",
                   "commits": [
                     "style: style"
                   ]
                 },
                 {
                   "category": "chore",
-                  "markdown_section_name": "Other",
+                  "markdown_section_name": "chore",
                   "commits": [
                     "chore: chore"
                   ]

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,14 +12,7 @@ on:
 env:
   ##### JOB ON/OFF SWITCHES - Top/1st level overrides #####
   RUN_UNIT_TESTS: "true"
-  DOCS_ON: "true"
   ###############################
-
-  #### DOCS Build/Test ####
-  ALWAYS_DOCS: "false"
-  DOCS_JOB_POLICY: '2'  # {2, 3}
-  DOCS_BUILDER_RUNTIME: "3.10"
-  ##########################
 
 jobs:
   ### TEST Action returns 'true' in Rule-passing End-2-End Scenarios ###
@@ -116,28 +109,12 @@ jobs:
           ]
         }
 
-  ### DOCS BUILD/TEST - DOCUMENTATION SITE ###
-  docs:
-    # IF PIPE_DOCS_POLICY != 0, will trigger by processing rules in order till TRUE
-    # - run_policy == 1
-    # - push event on 'main' branch AND run_policy == 2
-    # - push event of "v*" tag AND run_policy == 2
-    # - Documentation Changes Detected
-    name: Build Documentation
-    uses: boromir674/automated-workflows/.github/workflows/policy_docs.yml@v1.13.1
-    with:
-      # 0: OFF, 1: Always, 2: Content Dynamic + Dedicated Branches, 3: Content Dynamic
-      run_policy: "${{ (vars.OVERRIDE_DOCS == 'false' && '0') || (vars.OVERRIDE_DOCS == 'true' && '1') || '2' }}"
-      python_version: '3.10'
-      dedicated_branches: 'main, release'  #  only relevant when policy = 2
-      command: 'tox -s false -e pin-deps -- -E docs && tox -e docs --sitepackages -vv -s false'
-
   ### CI Checks - Quality Logic Gate ###
   quality_gate:
     # This Workflow implements both CI and CD, with its Jobs.
     # So we put the Quality Gate for Dynamic Acceptance/Check here, which should be wired up to the CI Jobs.
     if: always()
-    needs: ['test', 'docs']
+    needs: ['test']
     uses: boromir674/automated-workflows/.github/workflows/go-single-status.yml@v1.13.1
     with:
       # leverage inputs to dynamically control the Acceptance Criteria

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -20,7 +20,7 @@ jobs:
     if: vars.OVERRIDE_UNIT_TESTS == 'true' || vars.OVERRIDE_UNIT_TESTS != 'false'
     uses: ./.github/workflows/_test.yml
     with:
-      test_matrix: |
+      test_matrix: >
         {
           "test_data": [
             {

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  label_PR:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    # This Job behaves as a Listener to PR events, and each step is a Handler
+    steps:
+      # HANDLER 1: Label PR, given file changes and Labeling Rules '.github/labeler.yml'
+      - uses: actions/labeler@v5
+        with:
+          # if you want your labels to trigger other Workflows, pass-in a PAT
+          # with permission for label creation events to trigger listeners
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This project adheres to [Semantic Versioning](https://semver.org/).
+
+## 1.0.0 (2024-08-24)
+
+### Changes
+
+#### Feature
+- use `raw Categories`, when `Markdown Headers` are created from comma-separated inputs.categories
+- add 'composite' action with **Inputs** `commits`, `output_format`, and `categories`
+
+#### Fix
+- strip grouped commits from \<category\>: prefix pattern found in commit subject
+- do not return Categories, that have no commits
+- convert input.commits to UNICODE and store as env var
+- use toJSON to process Inputs.commits JSON array data
+
+#### Test
+- change Test Data to expect commits stripped of \<category\>: prefix pattern
+- add another JSON-output Test Case with minimal data
+- test expected JSON array of Objects is returned when inputs.output_format == 'JSON'
+- test order of commits is preserved
+- render the Action Outputs.content in Job Summary
+
+#### Docs
+- document `Action inputs/outputs` and add example usage in **README.md**
+- update `Action Logic Flowchart Diagram`, in **README.md**
+
+#### CI
+- allow Test Cases to continue running when another one fails
+- print the Action Output Content in Job Summary, conditionally on format MD/JSON
+- dynamically assert expected Markdown or JSON content
+- setup CI/CD Pipeline and Parallel Tests, using Job Matrix
+
+
+## 0.1.0
+
+This is the **first** ever release of the **Action Generate Changelog** Open-Source Project.
+- The project is hosted in a public repository on GitHub at [https://github.com/boromir674/action-generate-changelog](https://github.com/boromir674/action-generate-changelog)
+
+### Initial Sources
+
+- **CI/CD Pipeline** running on GitHub Actions at [https://github.com/boromir674/action-generate-changelog/actions](https://github.com/boromir674/action-generate-changelog)

--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@
 
 [![GitHub branch status](https://img.shields.io/github/checks-status/boromir674/action-generate-changelog/main?label=CI%2FCD)](https://github.com/boromir674/action-generate-changelog/actions/workflows/cicd.yml)
 ![GitHub Tag](https://img.shields.io/github/v/tag/boromir674/action-generate-changelog?sort=semver)
-![GitHub Release](https://img.shields.io/github/v/release/boromir674/action-generate-changelog?sort=semver&color=blue&link=https%3A%2F%2Fgithub.com%2Fboromir674%2Faction-generate-changelog%2Freleases%2Ftag%2Fv0.1.0)
-[![License](https://img.shields.io/github/license/boromir674/action-generate-changelog)](https://github.com/boromir674/action-generate-changelog/blob/main/LICENSE)
-[![GitHub commits since tagged version (branch)](https://img.shields.io/github/commits-since/boromir674/action-generate-changelog/v0.1.0/main?color=blue&logo=github)](https://github.com/boromir674/action-generate-changelog/compare/v0.1.0..main)
+![GitHub Release](https://img.shields.io/github/v/release/boromir674/action-generate-changelog?sort=semver&color=blue)
 ![GitHub commits since latest release (by SemVer)](https://img.shields.io/github/commits-since/boromir674/action-generate-changelog/latest?color=blue&logo=semver&sort=semver)
+[![License](https://img.shields.io/github/license/boromir674/action-generate-changelog)](https://github.com/boromir674/action-generate-changelog/blob/main/LICENSE)
 
 
 
@@ -79,6 +78,9 @@ if_format_is_md_2 -- YES --> gen_output_md_sections
 ```
 
 ## Features
+- reads `commits` encoded as JSON Array
+- supports `Markdown` or `JSON` **Output**
+- parsing `Conventional Commits` or configure your own `Categories`
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
 flowchart LR
 
 %% CONDITIONS
-if_group{"`if **group** = 'true'`"}
-if_format_is_md{"`if **format** = 'MD'`"}
+%%% NOTE: so far it seems that it is a redundant use case to support group=false
+%% if_group{"`if **group** = 'true'`"}
+%% if_format_is_md{"`if **format** = 'MD'`"}
+
 if_format_is_md_2{"`if **format** = 'MD'`"}
 if_categories_input_is_supplied{"`**categories** given
 in action input?`"}
@@ -16,11 +18,12 @@ if_user_categories_files_found{"`**.github/categories.md**
 file exists?`"}
 
 %% FINAL NODES
-gen_output_same_as_input(("`**OUTPUT:**
-**JSON** Array of strings
-same as input`"))
-gen_output_md_list_from_input_json_array(("`**OUTPUT:**
-**MD list** of commits`"))
+%% gen_output_same_as_input(("`**OUTPUT:**
+%% **JSON** Array of strings
+%% same as input`"))
+%% gen_output_md_list_from_input_json_array(("`**OUTPUT:**
+%% **MD list** of commits`"))
+
 gen_output_as_json_array(("`**OUTPUT:**
 **JSON** Array of Objects`"))
 gen_output_md_sections(("`**OUTPUT:**
@@ -34,19 +37,20 @@ use_categories_from_user_file("`Use **Categories**
 from user file`")
 use_categories_from_built_in_default("`Use **Built-in Default**
 **Categories**`")
-group_commits_using_categories(("`**Group Commits**
-using Categories`"))
+group_commits_using_categories("`**Group Commits**
+using Categories`")
 
 
 %% FLOW / LOGIC GRAPH
 
 %%% group flag is FALSE
-if_group -- NO --> if_format_is_md
-if_format_is_md -- NO --> gen_output_same_as_input
-if_format_is_md -- YES --> gen_output_md_list_from_input_json_array
+%%% NOTE: so far it seems that it is a redundant use case to support group=false
+%% if_group -- NO --> if_format_is_md
+%% if_format_is_md -- NO --> gen_output_same_as_input
+%% if_format_is_md -- YES --> gen_output_md_list_from_input_json_array
 
 %%% group flag is TRUE
-if_group -- YES --> if_categories_input_is_supplied
+%% (see NOTE) if_group -- YES --> if_categories_input_is_supplied
 
 if_categories_input_is_supplied -- YES --> use_categories_input
 use_categories_input --> group_commits_using_categories
@@ -72,8 +76,6 @@ if_format_is_md_2 -- YES --> gen_output_md_sections
 ### `commits` (str)
 
 ### `format` (str)
-
-### `group` (bool)
 
 ### `categories` (str)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 > Generate `Release Changelog` from Commit Subjects.
 
+[![GitHub branch status](https://img.shields.io/github/checks-status/boromir674/action-generate-changelog/main?label=CI%2FCD)](https://github.com/boromir674/action-generate-changelog/actions/workflows/cicd.yml)
+![GitHub Tag](https://img.shields.io/github/v/tag/boromir674/action-generate-changelog?sort=semver)
+![GitHub Release](https://img.shields.io/github/v/release/boromir674/action-generate-changelog?sort=semver&color=blue&link=https%3A%2F%2Fgithub.com%2Fboromir674%2Faction-generate-changelog%2Freleases%2Ftag%2Fv0.1.0)
+[![License](https://img.shields.io/github/license/boromir674/action-generate-changelog)](https://github.com/boromir674/action-generate-changelog/blob/main/LICENSE)
+[![GitHub commits since tagged version (branch)](https://img.shields.io/github/commits-since/boromir674/action-generate-changelog/v0.1.0/main?color=blue&logo=github)](https://github.com/boromir674/action-generate-changelog/compare/v0.1.0..main)
+![GitHub commits since latest release (by SemVer)](https://img.shields.io/github/commits-since/boromir674/action-generate-changelog/latest?color=blue&logo=semver&sort=semver)
+
+
+
 ```mermaid
 %%{init: {"flowchart": {"htmlLabels": false}} }%%
 flowchart LR
@@ -74,16 +83,125 @@ if_format_is_md_2 -- YES --> gen_output_md_sections
 ## Inputs
 
 ### `commits` (str)
+> Commit Subjects as JSON array of strings.
+
+Example **value**:
+```json
+[
+    "feat: add feature X2",
+    "test: add Test Case for feature X2",
+    "fix: fix feature X1",
+    "feat: add feature X1"
+]
+```
 
 ### `format` (str)
+> The format, 'MD' (for Markdown) or 'JSON', to use for the Action Output
+
+Example **value**: `MD` or `JSON`
 
 ### `categories` (str)
+> Comma-separated Categories to use for grouping the Commits.
 
+Example **value**:
+```
+feat,fix,refactor,test,build,docs,ci,style,chore
+```
 ## Outputs
 
 ### `content` (str)
+> Either **Markdown** Sections, each with a list, or **JSON** array of Objects
 
-## Example
+#### Example **Markdown value**
+```markdown
+## feat
+- add feature `X2`
+- add feature `X1`
 
+## fix
+- handle corner case for input X in function Y
+
+## test
+- test feature X returns expected data
+
+## docs
+- add Documentation Sources for `mkdocs` build
+
+## ci
+- add CI/CD Pipeline
+
+```
+
+#### Example **JSON value**
+```json
+[
+  {
+    "category": "feat",
+    "commits": [
+      "add feature X2",
+      "add feature X1"
+    ]
+  },
+  {
+    "category": "fix",
+    "commits": [
+      "handle corner case for input X in function Y"
+    ]
+  },
+  {
+    "category": "test",
+    "commits": [
+      "test feature X returns expected data"
+    ]
+  },
+  {
+    "category": "ci",
+    "commits": [
+      "add CI/CD Pipeline"
+    ]
+  }
+]
+```
+
+## Examples
+
+> Retrieve Value with `${{ steps.groups.commits.output.content }}`, in your next Job steps.
+
+## With static input
 ```yaml
+jobs:
+  my_jobs:
+  runs-on: ubuntu-latest
+  steps:
+    - name: Group Commits under Markdown Sections
+      id: group_commits
+      uses: boromir674/action-generate-changelog@v1.0.0
+      with:
+          commits: |
+            '[
+                "feat: add feature X2",
+                "test: test feature X2 returns expected data",
+                "fix: handle corner case for X1 function input",
+                "feat: add feature X1",
+                "ci: add CI/CD Pipeline"
+            ]'
+          output_format: 'MD'
+          categories: 'feat,fix,refactor,test,build,docs,ci,style,chore'
+```
+Returns `Markdown Content` as **multi-line Unicode** string
+
+```markdown
+## feat
+- add feature X2
+- add feature X1
+
+## fix
+- handle corner case for X1 function inpu
+
+## test
+- test feature X2 returns expected data
+
+## ci
+- add CI/CD Pipeline
+
 ```

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,9 @@ outputs:
 
 runs:
   using: "composite"
+  env:
+    # implicit convertion to UNICODE string, by serializing inner JSON array representation
+    COMMITS_JSON_ARRAY_SERIALIZED: ${{ toJSON(inputs.commits) }}
   steps:
     # VERIFY INPUTS: commits is jq-parsable JSON array of strings
     - name: "VERIFY INPUTS: commits is jq-parsable JSON array of strings"
@@ -69,7 +72,7 @@ runs:
         COMMITS_JSON_ARRAY_SERIALIZED: ${{ toJSON(inputs.commits) }}
       run: |
         # Get Commits from Input
-        COMMITS=$(echo ${{ toJSON(inputs.commits) }} | jq -rc .)
+        COMMITS=$(echo "${COMMITS_JSON_ARRAY_SERIALIZED}" | jq -rc .)
 
         # Group Commits into Categories: {category: str, commits: str[]}[]
         echo $COMMITS | jq -r --argjson categories "${CATEGORIES}" '

--- a/action.yml
+++ b/action.yml
@@ -27,9 +27,6 @@ outputs:
 
 runs:
   using: "composite"
-  env:
-    # implicit convertion to UNICODE string, by serializing inner JSON array representation
-    COMMITS_JSON_ARRAY_SERIALIZED: ${{ toJSON(inputs.commits) }}
   steps:
     # VERIFY INPUTS: commits is jq-parsable JSON array of strings
     - name: "VERIFY INPUTS: commits is jq-parsable JSON array of strings"

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
             category: .,
             commits: $coms
           })
-        ' | jq '[.[] | . as $obj | .commits |= map(select(startswith($obj.category + ":")))]'
+        ' | jq '[.[] | . as $obj | .commits |= map(select(startswith($obj.category + ":"))) | select(.commits | length > 0)]'
 
         echo GROUPED_COMMITS=$(echo $COMMITS | jq -r --argjson categories "${CATEGORIES}" '
           . as $coms |
@@ -92,7 +92,7 @@ runs:
             category: .,
             commits: $coms
           })
-        ' | jq -c '[.[] | . as $obj | .commits |= map(select(startswith($obj.category + ":")))]')
+        ' | jq -c '[.[] | . as $obj | .commits |= map(select(startswith($obj.category + ":"))) | select(.commits | length > 0)]')
 
         GROUPED_COMMITS=$(echo $COMMITS | jq -r --argjson categories "${CATEGORIES}" '
           . as $coms |
@@ -101,7 +101,7 @@ runs:
             category: .,
             commits: $coms
           })
-        ' | jq -c '[.[] | . as $obj | .commits |= map(select(startswith($obj.category + ":")))]')
+        ' | jq -c '[.[] | . as $obj | .commits |= map(select(startswith($obj.category + ":"))) | select(.commits | length > 0)]')
 
         echo "[DEBUG] GROUPED_COMMITS: $GROUPED_COMMITS"
 

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ runs:
             category: .,
             commits: $coms
           })
-        ' | jq '[.[] | . as $obj | .commits |= map(select(startswith($obj.category + ":"))) | select(.commits | length > 0)]'
+        ' | jq -c '[.[] | . as $obj | .commits |= map(select(startswith($obj.category + ":"))) | select(.commits | length > 0)]'
 
         echo GROUPED_COMMITS=$(echo $COMMITS | jq -r --argjson categories "${CATEGORIES}" '
           . as $coms |
@@ -89,7 +89,7 @@ runs:
             category: .,
             commits: $coms
           })
-        ' | jq -c '[.[] | . as $obj | .commits |= map(select(startswith($obj.category + ":"))) | select(.commits | length > 0)]')
+        ' | jq -c '[.[] | . as $obj | .commits |= map(select(startswith($obj.category + ":")) | sub("^" + $obj.category + ": "; "")) | select(.commits | length > 0)]')
 
         GROUPED_COMMITS=$(echo $COMMITS | jq -r --argjson categories "${CATEGORIES}" '
           . as $coms |
@@ -98,7 +98,7 @@ runs:
             category: .,
             commits: $coms
           })
-        ' | jq -c '[.[] | . as $obj | .commits |= map(select(startswith($obj.category + ":"))) | select(.commits | length > 0)]')
+        ' | jq -c '[.[] | . as $obj | .commits |= map(select(startswith($obj.category + ":")) | sub("^" + $obj.category + ": "; "")) | select(.commits | length > 0)]')
 
         echo "[DEBUG] GROUPED_COMMITS: $GROUPED_COMMITS"
 

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ outputs:
   content:
     description: >
       Either MD Sections, each with a list, or JSON array of Objects
-    value: ${{ steps.set_output.outputs.content }}
+    value: ${{ inputs.output_format == 'MD' && steps.to_markdown.outputs.content || steps.to_json.outputs.content }}
 
 runs:
   using: "composite"
@@ -65,6 +65,7 @@ runs:
 
     # GROUP Commits into Categories JSON Array of Objects {category: str, commits: str[]}
     - name: Groups Commits into Categories JSON Array
+      id: to_json
       env:
         # Get Categories from User (file or action input) or Default
         CATEGORIES: ${{ steps.set_categories.output.INPUT_CATEGORIES || '["feat","fix","refactor","test","build","docs","ci","style","chore"]' }}
@@ -105,11 +106,13 @@ runs:
         echo "[DEBUG] GROUPED_COMMITS: $GROUPED_COMMITS"
 
         echo GROUPED_COMMITS="${GROUPED_COMMITS}" >> $GITHUB_ENV
+        echo content="${GROUPED_COMMITS}" >> $GITHUB_OUTPUT
       shell: bash
 
     # CONVERT to Markdown, if requested
     - name: Convert to Markdown, if '${{ inputs.output_format }}' == 'MD'
       if: ${{ inputs.output_format == 'MD' }}
+      id: to_markdown
       # Convert to Markdown like
       # ## Section Name
       # - commit 1
@@ -123,18 +126,19 @@ runs:
           (.commits | map("- " + .) | join("\n")) + 
           "\n"
         '
-        echo GROUPED_COMMITS=$(echo "$GROUPED_COMMITS" | jq -r '
+        GROUPED_COMMITS=$(echo "$GROUPED_COMMITS" | jq -r '
           .[] |
           select(.commits | length > 0) |  # Only select categories with non-empty commits
           "## \(.category)\n" + 
           (.commits | map("- " + .) | join("\n")) + 
           "\n"
-        ') >> $GITHUB_ENV
-      shell: bash
+        ')
 
-    - name: Set Output
-      id: set_output
-      run: echo content="${GROUPED_COMMITS}" >> $GITHUB_OUTPUT
+        ## Take care of multi-line Markdown content
+        echo "content<<EOF" >> $GITHUB_OUTPUT
+        echo "${GROUPED_COMMITS}" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
+
       shell: bash
 
 branding:

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,142 @@
+name: 'Commit Groups Generator'
+author: Konstantinos Lampridis
+description: "Group Commits into Categories and output in MD or JSON format."
+
+inputs:
+  commits:
+    description: >
+      Commit Subjects as JSON array of strings.
+    required: true
+  output_format:
+    description: >
+      The format, 'MD' (for Markdown) or 'JSON', to use for the Action Output
+    required: false
+    default: 'MD'
+  categories:
+    description: >
+      Comma-separated Categories to use for grouping the Commits.
+      Example: 'feat,fix,refactor,test,build,docs,ci,style,chore'.
+    required: false
+
+outputs:
+  # Outputs are Unicode strings, and can be a maximum of 1 MB. The total of all outputs in a workflow run can be a maximum of 50 MB.
+  content:
+    description: >
+      Either MD Sections, each with a list, or JSON array of Objects
+    value: ${{ steps.set_output.outputs.content }}
+
+runs:
+  using: "composite"
+  steps:
+    # VERIFY INPUTS: commits is jq-parsable JSON array of strings
+    - name: "VERIFY INPUTS: commits is jq-parsable JSON array of strings"
+      env:
+        COMMITS_JSON_ARRAY_SERIALIZED: ${{ toJSON(inputs.commits) }}
+      run: |
+        if ! jq -e . <<< "${COMMITS_JSON_ARRAY_SERIALIZED}" >/dev/null 2>&1; then
+          echo "[ERROR] Input 'commits' is not a valid JSON array of strings."
+          echo "Exiting with error."
+          exit 1
+        fi
+      shell: bash
+    # VERIFY INPUTS: format is either 'MD' or 'JSON'
+    - name: VERIFY INPUTS: format is either 'MD' or 'JSON'
+      run: |
+        if [ "${{ inputs.output_format }}" != "MD" ] && [ "${{ inputs.output_format }}" != "JSON" ]; then
+          echo "[ERROR] Input 'output_format' must be either 'MD' or 'JSON'."
+          echo "Exiting with error."
+          exit 1
+        fi
+      shell: bash
+
+    # STORE Categories as JSON Array
+    - if: ${{ inputs.categories }}
+      ## [IF] Categories from INPUTs: feat,test,ci --> ["feat","test","ci" ]
+      name: SET Categories JSON Array of strings, from Input 'categories'
+      id: set_categories
+      run: echo INPUT_CATEGORIES=$(echo ${{ inputs.categories }} | tr ',' '\n' | jq -R . | jq -sc .) >> $GITHUB_OUTPUT
+      shell: bash
+    # - if: ${{ ! inputs.categories }}
+    # TODO
+
+    # GROUP Commits into Categories JSON Array of Objects {category: str, commits: str[]}
+    - name: Groups Commits into Categories JSON Array
+      id: group_commits
+      env:
+        # Get Categories from Input or Default
+        CATEGORIES: ${{ steps.set_categories.output.INPUT_CATEGORIES || '["feat","fix","refactor","test","build","docs","ci","style","chore"]' }}
+        # implicit convertion to UNICODE string, by serializing inner JSON array representation
+        COMMITS_JSON_ARRAY_SERIALIZED: ${{ toJSON(inputs.commits) }}
+      run: |
+        # Get Commits from Input
+        COMMITS=$(echo ${{ inputs.commits }} | jq -rc .)
+
+        # Group Commits into Categories: {category: str, commits: str[]}[]
+        echo $COMMITS | jq -r --argjson categories "${CATEGORIES}" '
+          . as $coms |
+          $categories |
+          map({
+            category: .,
+            commits: $coms
+          })
+        ' | jq '[.[] | . as $obj | .commits |= map(select(startswith($obj.category + ":")))]'
+
+        echo GROUPED_COMMITS=$(echo $COMMITS | jq -r --argjson categories "${CATEGORIES}" '
+          . as $coms |
+          $categories |
+          map({
+            category: .,
+            commits: $coms
+          })
+        ' | jq -c '[.[] | . as $obj | .commits |= map(select(startswith($obj.category + ":")))]')
+
+        GROUPED_COMMITS=$(echo $COMMITS | jq -r --argjson categories "${CATEGORIES}" '
+          . as $coms |
+          $categories |
+          map({
+            category: .,
+            commits: $coms
+          })
+        ' | jq -c '[.[] | . as $obj | .commits |= map(select(startswith($obj.category + ":")))]')
+
+        echo "[DEBUG] GROUPED_COMMITS: $GROUPED_COMMITS"
+
+        echo GROUPED_COMMITS="${GROUPED_COMMITS}" >> $GITHUB_OUTPUT
+      shell: bash
+
+    # CONVERT to Markdown, if requested
+    - name: Convert to Markdown, if '${{ inputs.output_format }}' == 'MD'
+      if: ${{ inputs.output_format == 'MD' }}
+      # Convert to Markdown like
+      # ## Section Name
+      # - commit 1
+      # - commit 2
+      # ...
+      id: set_output
+      # id: convert_to_md
+      run: |
+        echo "$GROUPED_COMMITS" | jq -r '
+          .[] |
+          select(.commits | length > 0) |  # Only select categories with non-empty commits
+          "## \(.category)\n" + 
+          (.commits | map("- " + .) | join("\n")) + 
+          "\n"
+        '
+        echo content=$(echo "$GROUPED_COMMITS" | jq -r '
+          .[] |
+          select(.commits | length > 0) |  # Only select categories with non-empty commits
+          "## \(.category)\n" + 
+          (.commits | map("- " + .) | join("\n")) + 
+          "\n"
+        ') >> $GITHUB_OUTPUT
+      shell: bash
+
+    - if: ${{ inputs.output_format != 'MD' }}
+      id: set_output
+      run: echo content="${GROUPED_COMMITS}" >> $GITHUB_OUTPUT
+      shell: bash
+
+branding:
+  icon: hash  # https://feathericons.com/
+  color: 'blue'  # background color of the badge
+  # white, black, yellow, blue, green, orange, red, purple, gray-dark

--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ runs:
         COMMITS_JSON_ARRAY_SERIALIZED: ${{ toJSON(inputs.commits) }}
       run: |
         # Get Commits from Input
-        COMMITS=$(echo ${{ inputs.commits }} | jq -rc .)
+        COMMITS=$(echo ${{ toJSON(inputs.commits) }} | jq -rc .)
 
         # Group Commits into Categories: {category: str, commits: str[]}[]
         echo $COMMITS | jq -r --argjson categories "${CATEGORIES}" '

--- a/action.yml
+++ b/action.yml
@@ -39,8 +39,9 @@ runs:
           exit 1
         fi
       shell: bash
+
     # VERIFY INPUTS: format is either 'MD' or 'JSON'
-    - name: VERIFY INPUTS: format is either 'MD' or 'JSON'
+    - name: "VERIFY INPUTS: format is either 'MD' or 'JSON'"
       run: |
         if [ "${{ inputs.output_format }}" != "MD" ] && [ "${{ inputs.output_format }}" != "JSON" ]; then
           echo "[ERROR] Input 'output_format' must be either 'MD' or 'JSON'."
@@ -61,9 +62,8 @@ runs:
 
     # GROUP Commits into Categories JSON Array of Objects {category: str, commits: str[]}
     - name: Groups Commits into Categories JSON Array
-      id: group_commits
       env:
-        # Get Categories from Input or Default
+        # Get Categories from User (file or action input) or Default
         CATEGORIES: ${{ steps.set_categories.output.INPUT_CATEGORIES || '["feat","fix","refactor","test","build","docs","ci","style","chore"]' }}
         # implicit convertion to UNICODE string, by serializing inner JSON array representation
         COMMITS_JSON_ARRAY_SERIALIZED: ${{ toJSON(inputs.commits) }}
@@ -101,7 +101,7 @@ runs:
 
         echo "[DEBUG] GROUPED_COMMITS: $GROUPED_COMMITS"
 
-        echo GROUPED_COMMITS="${GROUPED_COMMITS}" >> $GITHUB_OUTPUT
+        echo GROUPED_COMMITS="${GROUPED_COMMITS}" >> $GITHUB_ENV
       shell: bash
 
     # CONVERT to Markdown, if requested
@@ -112,8 +112,6 @@ runs:
       # - commit 1
       # - commit 2
       # ...
-      id: set_output
-      # id: convert_to_md
       run: |
         echo "$GROUPED_COMMITS" | jq -r '
           .[] |
@@ -122,16 +120,16 @@ runs:
           (.commits | map("- " + .) | join("\n")) + 
           "\n"
         '
-        echo content=$(echo "$GROUPED_COMMITS" | jq -r '
+        echo GROUPED_COMMITS=$(echo "$GROUPED_COMMITS" | jq -r '
           .[] |
           select(.commits | length > 0) |  # Only select categories with non-empty commits
           "## \(.category)\n" + 
           (.commits | map("- " + .) | join("\n")) + 
           "\n"
-        ') >> $GITHUB_OUTPUT
+        ') >> $GITHUB_ENV
       shell: bash
 
-    - if: ${{ inputs.output_format != 'MD' }}
+    - name: Set Output
       id: set_output
       run: echo content="${GROUPED_COMMITS}" >> $GITHUB_OUTPUT
       shell: bash


### PR DESCRIPTION
- docs: update README.md
- feat: add 'composite' action with Inputs 'commits', 'output_format', and 'categories'
- ci(pipe): setup CI/CD Pipeline and Parallel Tests, using Job Matrix
- fix: use toJSON to process Inputs.commits JSON array data
- fix: convert input.commits to UNICODE and store as env var
- feat: use raw Categories, when Markdown Headers are created from comma-separated inputs.categories
- ci: remove Docs Job/Workflow
- ci: dynamically assert expected Markdown or JSON content
- test: render the Action Outputs.content in Job Summary
- test: test order of commits is preserved
- test: test expected JSON array of Objects is returned when inputs.output_format == 'JSON'
- test: fix expected content comparison when format is JSON
- test: add another JSON-output Test Case with minimal data
- fix: do not return Categories, that have no commits
- test: fix expected Data for Test Case 3
- fix: do not use 'runs.env' in Composite Action YAML
- ci: print the Action Output Content in Job Summary, conditionally on format MD/JSON
- test: remove irrelevant markdown section expectation from JSON-format Test Case 2
- test: change Test Data to expect commits stripped of <category>: prefix
- fix: strip grouped commits from <category>: prefix found in commit subject
- ci: allow Test Cases to continue running when another one fails
- docs(readme.md): document action inputs/outputs and add example usage in README.md
- chore(changelog.md): add CHANGELOG.md with v0.1.0 and v1.0.0 Release Entries
- docs: update README.md
